### PR TITLE
Map numbered candidates back to input names

### DIFF
--- a/examples/vote4names.list
+++ b/examples/vote4names.list
@@ -1,0 +1,6 @@
+4
+3=alpha;charlie;delta;bravo
+9=bravo;alpha;charlie;delta
+8=charlie;delta;alpha;bravo
+5=delta;alpha;bravo;charlie
+5=delta;bravo;charlie;alpha

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -79,7 +79,7 @@ module Vote
       def calculate_ranking_abc
         @ranking_abc =
           @ranking
-          .map { |e| [e, @candidate_names[@ranking.index(e)]] }
+          .map.with_index { |e, i| [e, @candidate_names[i]] }
           .sort
           .reverse
           .map do |e|

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -9,7 +9,8 @@ module Vote
       end
 
       attr_reader :voting_matrix, :play_matrix, :result_matrix,
-                  :ranking, :ranking_abc, :candidate_count, :voting_count
+                  :ranking, :ranking_abc, :candidate_count, :voting_count,
+                  :candidate_names
 
       def initialize(voting_matrix, candidate_count = nil)
         unless voting_matrix.is_a?(Vote::Schulze::Input)

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -18,6 +18,7 @@ module Vote
         @voting_matrix = voting_matrix.voting_matrix
         @candidate_count = voting_matrix.candidate_count
         @voting_count = voting_matrix.voting_count
+        @candidate_names = voting_matrix.candidate_names
         @play_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
         @result_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
       end
@@ -77,10 +78,13 @@ module Vote
       def calculate_ranking_abc
         @ranking_abc =
           @ranking
-          .map { |e| [e, (@ranking.index(e) + 65).chr] }
+          .map { |e| [e, @candidate_names[@ranking.index(e)]] }
           .sort
           .reverse
-          .map { |e| "#{e[1]}:#{@ranking.max - e[0] + 1}" } # => "letter:int"
+          .map do |e|
+            "#{e[1].length == 1 ? e[1].upcase : e[1]}:" +
+            "#{@ranking.max - e[0] + 1}"
+           end
       end
     end
   end

--- a/lib/vote/schulze/input.rb
+++ b/lib/vote/schulze/input.rb
@@ -3,7 +3,8 @@
 module Vote
   module Schulze
     class Input
-      attr_reader :candidate_count, :voting_count, :voting_matrix
+      attr_reader :candidate_count, :voting_count, :voting_matrix,
+        :candidate_names
 
       def initialize(voting_data, candidate_count = nil)
         @voting_data = voting_data
@@ -50,6 +51,7 @@ module Vote
             end
           end
 
+          @candidate_names ||= tmp2.map { |e| e[0] }.sort
           vote = tmp2.sort.map { |e| e[1] } # order, strip & add
           vcount.times do
             voting_array << vote

--- a/spec/vote/schulze/basic_spec.rb
+++ b/spec/vote/schulze/basic_spec.rb
@@ -11,4 +11,13 @@ RSpec.describe Vote::Schulze::Basic do
       expect(voting.ranking_abc).to eq(expected_result)
     end
   end
+  context 'when input is with names' do
+    let(:input_data) { File.open('examples/vote4names.list') }
+    let(:expected_result) { ['charlie:1', 'delta:2', 'bravo:3', 'alpha:4'] }
+    let(:voting) { described_class.call(input_data) }
+
+    it 'produces ranks by name' do
+      expect(voting.ranking_abc).to eq(expected_result)
+    end
+  end
 end


### PR DESCRIPTION
An input with names, such as:
chili;corn;hot dog;hamburger
hamburger;corn;chili;hot dog
produces output that contains indexes to the sorted list, or "A", "B", "C", ....

This PR causes `ranking_abc` to produce output that contains the original names.
