### PR TITLE
Expose the parsed voting data for analysis

### DIFF
--- a/examples/vote4names.list
+++ b/examples/vote4names.list
@@ -1,0 +1,6 @@
+4
+3=alpha;charlie;delta;bravo
+9=bravo;alpha;charlie;delta
+8=charlie;delta;alpha;bravo
+5=delta;alpha;bravo;charlie
+5=delta;bravo;charlie;alpha

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -4,23 +4,23 @@ module Vote
   module Schulze
     class Basic
       # All-in-One class method to get a calculated SchulzeBasic object
-      def self.call(voting_matrix, candidate_count = nil)
-        new(voting_matrix, candidate_count).call
+      def self.call(voting_data, candidate_count = nil)
+        new(voting_data, candidate_count).call
       end
 
       attr_reader :voting_matrix, :play_matrix, :result_matrix,
                   :ranking, :ranking_abc, :candidate_count, :voting_count,
                   :candidate_names, :votes
 
-      def initialize(voting_matrix, candidate_count = nil)
-        unless voting_matrix.is_a?(Vote::Schulze::Input)
-          voting_matrix = Vote::Schulze::Input.new(voting_matrix, candidate_count)
+      def initialize(voting_data, candidate_count = nil)
+        unless voting_data.is_a?(Vote::Schulze::Input)
+          voting_data = Vote::Schulze::Input.new(voting_data, candidate_count)
         end
-        @voting_matrix = voting_matrix.voting_matrix
-        @candidate_count = voting_matrix.candidate_count
-        @voting_count = voting_matrix.voting_count
-        @candidate_names = voting_matrix.candidate_names
-        @votes = voting_matrix.votes
+        @voting_matrix = voting_data.voting_matrix
+        @candidate_count = voting_data.candidate_count
+        @voting_count = voting_data.voting_count
+        @candidate_names = voting_data.candidate_names
+        @votes = voting_data.votes
         @play_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
         @result_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
       end

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -9,7 +9,8 @@ module Vote
       end
 
       attr_reader :voting_matrix, :play_matrix, :result_matrix,
-                  :ranking, :ranking_abc, :candidate_count, :voting_count
+                  :ranking, :ranking_abc, :candidate_count, :voting_count,
+                  :candidate_names
 
       def initialize(voting_matrix, candidate_count = nil)
         unless voting_matrix.is_a?(Vote::Schulze::Input)
@@ -18,6 +19,7 @@ module Vote
         @voting_matrix = voting_matrix.voting_matrix
         @candidate_count = voting_matrix.candidate_count
         @voting_count = voting_matrix.voting_count
+        @candidate_names = voting_matrix.candidate_names
         @play_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
         @result_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
       end
@@ -77,10 +79,13 @@ module Vote
       def calculate_ranking_abc
         @ranking_abc =
           @ranking
-          .map { |e| [e, (@ranking.index(e) + 65).chr] }
+          .map.with_index { |e, i| [e, @candidate_names[i]] }
           .sort
           .reverse
-          .map { |e| "#{e[1]}:#{@ranking.max - e[0] + 1}" } # => "letter:int"
+          .map do |e|
+            "#{e[1].length == 1 ? e[1].upcase : e[1]}:" +
+            "#{@ranking.max - e[0] + 1}"
+           end
       end
     end
   end

--- a/lib/vote/schulze/basic.rb
+++ b/lib/vote/schulze/basic.rb
@@ -10,7 +10,7 @@ module Vote
 
       attr_reader :voting_matrix, :play_matrix, :result_matrix,
                   :ranking, :ranking_abc, :candidate_count, :voting_count,
-                  :candidate_names
+                  :candidate_names, :votes
 
       def initialize(voting_matrix, candidate_count = nil)
         unless voting_matrix.is_a?(Vote::Schulze::Input)
@@ -20,6 +20,7 @@ module Vote
         @candidate_count = voting_matrix.candidate_count
         @voting_count = voting_matrix.voting_count
         @candidate_names = voting_matrix.candidate_names
+        @votes = voting_matrix.votes
         @play_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
         @result_matrix = ::Matrix.scalar(@candidate_count, 0).extend(Vote::Matrix)
       end

--- a/lib/vote/schulze/input.rb
+++ b/lib/vote/schulze/input.rb
@@ -3,7 +3,8 @@
 module Vote
   module Schulze
     class Input
-      attr_reader :candidate_count, :voting_count, :voting_matrix
+      attr_reader :candidate_count, :voting_count, :voting_matrix,
+        :candidate_names
 
       def initialize(voting_data, candidate_count = nil)
         @voting_data = voting_data
@@ -50,6 +51,7 @@ module Vote
             end
           end
 
+          @candidate_names ||= tmp2.map { |e| e[0] }.sort
           vote = tmp2.sort.map { |e| e[1] } # order, strip & add
           vcount.times do
             voting_array << vote

--- a/lib/vote/schulze/input.rb
+++ b/lib/vote/schulze/input.rb
@@ -4,7 +4,7 @@ module Vote
   module Schulze
     class Input
       attr_reader :candidate_count, :voting_count, :voting_matrix,
-        :candidate_names
+        :candidate_names, :votes
 
       def initialize(voting_data, candidate_count = nil)
         @voting_data = voting_data
@@ -20,6 +20,7 @@ module Vote
       end
 
       def insert_voting_array(voting_array)
+        @votes = voting_array
         voting_array.each do |vote|
           @voting_matrix.each_with_index do |_e, x, y|
             next if x == y

--- a/lib/vote/schulze/input.rb
+++ b/lib/vote/schulze/input.rb
@@ -35,23 +35,24 @@ module Vote
           voter = voter.split('=')
           vcount = voter.size == 1 ? 1 : voter[0].to_i
 
-          vcount.times do
-            tmp = voter.last.split(';')
-            tmp2 = []
+          tmp = voter.last.split(';')
+          tmp2 = []
 
-            tmp.map! { |e| [e, @candidate_count - tmp.index(e)] }
-            # find equal-weighted candidates
-            tmp.map do |e|
-              if e[0].size > 1
-                e[0].split(',').each do |f|
-                  tmp2 << [f, e[1]]
-                end
-              else
-                tmp2 << e
+          tmp.map! { |e| [e, @candidate_count - tmp.index(e)] }
+          # find equal-weighted candidates
+          tmp.map do |e|
+            if e[0].size > 1
+              e[0].split(',').each do |f|
+                tmp2 << [f, e[1]]
               end
+            else
+              tmp2 << e
             end
+          end
 
-            voting_array << (tmp2.sort.map { |e| e[1] }) # order, strip & add
+          vote = tmp2.sort.map { |e| e[1] } # order, strip & add
+          vcount.times do
+            voting_array << vote
           end
         end
 

--- a/spec/vote/schulze/basic_spec.rb
+++ b/spec/vote/schulze/basic_spec.rb
@@ -11,4 +11,13 @@ RSpec.describe Vote::Schulze::Basic do
       expect(voting.ranking_abc).to eq(expected_result)
     end
   end
+  context 'when input is with names' do
+    let(:input_data) { File.open('examples/vote4names.list') }
+    let(:expected_result) { ['charlie:1', 'delta:2', 'bravo:3', 'alpha:4'] }
+    let(:voting) { described_class.call(input_data) }
+
+    it 'produces ranks by name' do
+      expect(voting.ranking_abc).to eq(expected_result)
+    end
+  end
 end

--- a/spec/vote/schulze/basic_spec.rb
+++ b/spec/vote/schulze/basic_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe Vote::Schulze::Basic do
       expect(voting.ranking_abc).to eq(expected_result)
     end
   end
+
+  it 'exposes votes' do
+    input_data = "D;B;A;C\nD;A;B;C"
+    voting = described_class.call(input_data, 4)
+    expect(voting.votes).to eq([[2, 3, 1, 4], [3, 2, 1, 4]])
+  end
+
   context 'when input is with names' do
     let(:input_data) { File.open('examples/vote4names.list') }
     let(:expected_result) { ['charlie:1', 'delta:2', 'bravo:3', 'alpha:4'] }


### PR DESCRIPTION
It's useful to have the parsed voting data to compute, for example, rank correllation between the vote and the result. This is useful when the votes are not votes, per se, but ranking judgements. We can see how the individual judged rank correllates with the consensus result.